### PR TITLE
Cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,21 @@ A `tests.edn` example:
           :caioaao.kaocha-greenlight/new-system my.app/system-map}]}
 ```
 
+You may configure `kaocha-greenlight` to create a new system for each namespace,
+which can be useful if you'd like a clean state for each namespace, e.g. if
+you're using ephemeral datastores:
+
+```clojure
+#kaocha/v1
+{:tests [{:id           :integration
+          :type         :caioaao.kaocha-greenlight/test
+          :test-paths   ["test"]
+          :source-paths ["src"]
+          :ns-patterns  ["-flow$"]
+          :caioaao.kaocha-greenlight/new-system my.app/system-map
+          :caioaao.kaocha-greenlight/system-scope :ns}]}
+```
+
 For documentation on how to run tests, refer to [Kaocha](/lambdaisland/kaocha). For documentation regarding writing tests, refer to [Greenlight](/amperity/greenlight).
 
 ## License

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,23 @@
+(ns user
+  (:require
+   [clojure.spec.alpha :as s]
+   [expound.alpha :as expound]
+   [kaocha.repl]))
+
+;; Sets up the expound printer for human-readable spec error messages. kaocha
+;; requires this to be configured for generative fdef testing.
+
+
+;; Alter the root *explain-out* binding...
+(alter-var-root #'s/*explain-out* (constantly expound/printer))
+
+(try
+  ;; ...and attempt to set *explain-out*, assuming that we're inside of
+  ;; a binding context, which is necessary for some REPL configurations...
+  (set! s/*explain-out* expound/printer)
+
+  (catch IllegalStateException _
+    ;; ...however, we might not be inside a binding context. If not, Clojure
+    ;; will throw an IllegalStateException, which is why we're catching it and
+    ;; ignoring it here.
+))

--- a/project.clj
+++ b/project.clj
@@ -5,9 +5,12 @@
             :url  "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [amperity/greenlight "0.4.0"]
-                 [lambdaisland/kaocha "1.0.669"]]
+                 [lambdaisland/kaocha "1.0.672"]]
   :aliases {"test" ["run" "-m" "kaocha.runner"]}
-  :profiles {:dev {:dependencies [[nubank/matcher-combinators "0.4.2"]]
+  :profiles {:dev {:dependencies [[nubank/matcher-combinators "0.4.2"]
+                                  [org.clojure/test.check "1.1.0"]
+                                  [expound "0.8.5"]]
+                   :source-paths ["dev"]
                    :plugins      [[lein-cljfmt "0.6.1"]]}}
   :repl-options {:init-ns kaocha-greenlight.core}
   :release-tasks [["deploy" "clojars"]]

--- a/test/caioaao/kaocha_greenlight/scope_test.clj
+++ b/test/caioaao/kaocha_greenlight/scope_test.clj
@@ -11,14 +11,18 @@
 
 (mimic-matcher matchers/equals clojure.lang.Var)
 
-(def counter (atom 0))
+(def starts (atom 0))
+(def stops (atom 0))
 
 (defn new-system [& _]
   (component/system-map :greenlight.test-test/component
                         (with-meta {}
                           {`component/start (fn [this]
-                                              (swap! counter inc) this)
-                           `component/stop  identity})))
+                                              (swap! starts inc)
+                                              this)
+                           `component/stop  (fn [this]
+                                              (swap! stops inc)
+                                              this)})))
 
 (def test-suite-test {::testable/type                       :caioaao.kaocha-greenlight/test
                       ::testable/id                         :integration-test
@@ -35,15 +39,19 @@
                     :kaocha/source-paths                    ["src"]
                     :kaocha/test-paths                      ["test"]})
 
-(deftest test-tests
+(deftest scope-tests
   (testing "system is created once when system-scope is :test"
     (let [test-test-plan (testable/load test-suite-test)]
-      (reset! counter 0)
+      (reset! starts 0)
+      (reset! stops 0)
       (testable/run test-test-plan test-test-plan)
-      (is (= @counter 1))))
+      (is (= @starts 1))
+      (is (= @stops 1))))
 
   (testing "system is created per ns when system-scope is :ns"
     (let [ns-test-plan (testable/load test-suite-ns)]
-      (reset! counter 0)
+      (reset! starts 0)
+      (reset! stops 0)
       (testable/run ns-test-plan ns-test-plan)
-      (is (= @counter 3)))))
+      (is (= @starts 3))
+      (is (= @stops 3)))))

--- a/tests.edn
+++ b/tests.edn
@@ -1,1 +1,6 @@
-#kaocha/v1 {}
+#kaocha/v1
+ {:kaocha/plugins [:kaocha.plugin/profiling
+                   :kaocha.plugin.alpha/spec-test-check]
+
+  :clojure.spec.test.check/instrument?    true
+  :clojure.spec.test.check/check-asserts? true}


### PR DESCRIPTION
* Update kaocha again
* Add new configuration info to README
* Verify system stop counts in scope-test
* Enable generative fdef tests to automatically test specs as they are written
* Set up expound for better spec error output
* Enable test profiling

Not totally necessary to release this, but if you decide to, I think `0.2.1` would be sufficient as there are no API changes, just internal improvements.