### PR TITLE
Ensure that test plan has system and system-scope

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url  "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [amperity/greenlight "0.4.0"]
+                 [amperity/greenlight "0.5.0"]
                  [lambdaisland/kaocha "1.0.672"]]
   :aliases {"test" ["run" "-m" "kaocha.runner"]}
   :profiles {:dev {:dependencies [[nubank/matcher-combinators "0.4.2"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject caioaao/kaocha-greenlight "0.2.1-SNAPSHOT"
+(defproject caioaao/kaocha-greenlight "0.3.0"
   :description "Kaocha extension to run amperity/greenlight tests"
   :url "http://github.com/caioaao/kaocha-greenlight"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/caioaao/kaocha_greenlight/runner.clj
+++ b/src/caioaao/kaocha_greenlight/runner.clj
@@ -1,36 +1,25 @@
 (ns caioaao.kaocha-greenlight.runner
-  (:require [com.stuartsierra.component :as component]
-            [kaocha.testable :as testable]))
-
-(defn- resolve-system [system-fn-symbol]
-  (let [ns-name (symbol (namespace system-fn-symbol))]
-    (when-not (find-ns ns-name)
-      (require ns-name))
-    ((resolve system-fn-symbol))))
-
-(defn- run-testables
-  [testable test-plan]
-  (let [tests   (:kaocha.test-plan/tests testable)
-        results (testable/run-testables tests test-plan)]
-    (-> testable
-        (dissoc :kaocha.test-plan/tests)
-        (assoc :kaocha.result/tests results))))
+  (:require
+   [com.stuartsierra.component :as component]))
 
 (defn run
-  [testable
-   {:caioaao.kaocha-greenlight/keys [new-system system-scope]
-    :or                             {system-scope :test}
-    :as                             test-plan}
-   level]
-  (if-not (= system-scope level)
-    (run-testables testable test-plan)
-    (let [system    (-> new-system
-                        resolve-system
-                        component/start)
-          test-plan (assoc test-plan
-                           :caioaao.kaocha-greenlight.test/system
-                           system)]
-      (try
-        (run-testables testable test-plan)
-        (finally
-          (component/stop system))))))
+  [testable test-plan level run-fn]
+  (let [config       (select-keys testable
+                                  [:caioaao.kaocha-greenlight.test/system
+                                   :caioaao.kaocha-greenlight/system-scope])
+        test-plan    (merge test-plan config)
+        system-scope (get test-plan
+                          :caioaao.kaocha-greenlight/system-scope
+                          :test)]
+    (if-not (= system-scope level)
+      (run-fn testable test-plan)
+      (let [system    (-> test-plan
+                          :caioaao.kaocha-greenlight.test/system
+                          component/start)
+            test-plan (assoc test-plan
+                             :caioaao.kaocha-greenlight.test/system
+                             system)]
+        (try
+          (run-fn testable test-plan)
+          (finally
+            (component/stop system)))))))

--- a/src/caioaao/kaocha_greenlight/test/var.clj
+++ b/src/caioaao/kaocha_greenlight/test/var.clj
@@ -3,9 +3,7 @@
             [clojure.test :as ctest]
             [clojure.spec.alpha :as s]
             [kaocha.hierarchy :as hierarchy]
-            [kaocha.report :as kaocha.report]
             [greenlight.test :as test]
-            [kaocha.type]
             [greenlight.step :as step]))
 
 (defn test-results->kaocha [rs]
@@ -24,7 +22,7 @@
 
 (defmethod testable/-run :caioaao.kaocha-greenlight.test/var
   [{:caioaao.kaocha-greenlight.test/keys [test-var] :as testable}
-   {:caioaao.kaocha-greenlight.test/keys [system] :as test-plan}]
+   {:caioaao.kaocha-greenlight.test/keys [system]}]
   (ctest/do-report {:type :begin-test-var, :var test-var})
   (binding [ctest/*report-counters* (ref ctest/*initial-report-counters*)
             test/*report* (partial report {:print-color true})]

--- a/test/caioaao/kaocha_greenlight/error_suite/error_test.clj
+++ b/test/caioaao/kaocha_greenlight/error_suite/error_test.clj
@@ -1,0 +1,11 @@
+(ns caioaao.kaocha-greenlight.error-suite.error-test
+  (:require
+   [greenlight.step :as step]
+   [greenlight.test :refer [deftest]]))
+
+(deftest error-test
+  "A sample greenlight test in the error test suite"
+  #::step{:name   'error-step
+          :title  "Error Step"
+          :test   (fn [& _]
+                    (throw (ex-info "oh no!" {:some "data"})))})

--- a/test/caioaao/kaocha_greenlight/error_test.clj
+++ b/test/caioaao/kaocha_greenlight/error_test.clj
@@ -1,0 +1,34 @@
+(ns caioaao.kaocha-greenlight.error-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [com.stuartsierra.component :as component]
+            [kaocha.api :as api]
+            [kaocha.result :as result]
+            [matcher-combinators.test]
+            [matcher-combinators.matchers :as matchers]
+            [matcher-combinators.parser :refer [mimic-matcher]]))
+
+(mimic-matcher matchers/equals clojure.lang.Var)
+
+(defn new-system
+  [& _]
+  (component/system-map :greenlight.test-test/component {}))
+
+(def error-config
+  {:kaocha/tests [{:kaocha.testable/type :caioaao.kaocha-greenlight/test
+                   :kaocha.testable/id   :integration-test
+                   :kaocha/ns-patterns   ["error-suite.*-test$"]
+                   :kaocha/source-paths  ["src"]
+                   :kaocha/test-paths    ["test"]
+
+                   :caioaao.kaocha-greenlight/new-system 'caioaao.kaocha-greenlight.error-test/new-system}]})
+
+(deftest error-tests
+  (testing "correctly handles errors"
+    (is (match? #:kaocha.result{:count   1
+                                :error   1
+                                :fail    0
+                                :pass    0
+                                :pending 0}
+                (-> error-config
+                    api/run
+                    result/testable-totals)))))

--- a/test/caioaao/kaocha_greenlight/scope_test.clj
+++ b/test/caioaao/kaocha_greenlight/scope_test.clj
@@ -1,20 +1,17 @@
 (ns caioaao.kaocha-greenlight.scope-test
   (:require [clojure.test :refer [deftest testing is]]
             [com.stuartsierra.component :as component]
-            [kaocha.testable :as testable]
-            [kaocha.result]
-            [matcher-combinators.test]
-            [matcher-combinators.parser :refer [mimic-matcher]]
-            [caioaao.kaocha-greenlight.test-suite.blue-test]
-            [caioaao.kaocha-greenlight.test-suite.red-test]
-            [matcher-combinators.matchers :as matchers]))
+            [kaocha.api :as api]
+            [matcher-combinators.matchers :as matchers]
+            [matcher-combinators.parser :refer [mimic-matcher]]))
 
 (mimic-matcher matchers/equals clojure.lang.Var)
 
 (def starts (atom 0))
 (def stops (atom 0))
 
-(defn new-system [& _]
+(defn new-system
+  [& _]
   (component/system-map :greenlight.test-test/component
                         (with-meta {}
                           {`component/start (fn [this]
@@ -24,34 +21,36 @@
                                               (swap! stops inc)
                                               this)})))
 
-(def test-suite-test {::testable/type                       :caioaao.kaocha-greenlight/test
-                      ::testable/id                         :integration-test
-                      :caioaao.kaocha-greenlight/new-system 'caioaao.kaocha-greenlight.scope-test/new-system
-                      :kaocha/ns-patterns                   ["scope-suite.*-test$"]
-                      :kaocha/source-paths                  ["src"]
-                      :kaocha/test-paths                    ["test"]})
+(def test-config
+  {:kaocha/tests [{:kaocha.testable/type :caioaao.kaocha-greenlight/test
+                   :kaocha.testable/id   :integration-test
+                   :kaocha/ns-patterns   ["scope-suite.*-test$"]
+                   :kaocha/source-paths  ["src"]
+                   :kaocha/test-paths    ["test"]
 
-(def test-suite-ns {::testable/type                         :caioaao.kaocha-greenlight/test
-                    ::testable/id                           :integration-test
-                    :caioaao.kaocha-greenlight/new-system   'caioaao.kaocha-greenlight.scope-test/new-system
-                    :caioaao.kaocha-greenlight/system-scope :ns
-                    :kaocha/ns-patterns                     ["scope-suite.*-test$"]
-                    :kaocha/source-paths                    ["src"]
-                    :kaocha/test-paths                      ["test"]})
+                   :caioaao.kaocha-greenlight/new-system 'caioaao.kaocha-greenlight.scope-test/new-system}]})
+
+(def ns-config
+  {:kaocha/tests [{:kaocha.testable/type :caioaao.kaocha-greenlight/test
+                   :kaocha.testable/id   :integration-test
+                   :kaocha/ns-patterns   ["scope-suite.*-test$"]
+                   :kaocha/source-paths  ["src"]
+                   :kaocha/test-paths    ["test"]
+
+                   :caioaao.kaocha-greenlight/new-system   'caioaao.kaocha-greenlight.scope-test/new-system
+                   :caioaao.kaocha-greenlight/system-scope :ns}]})
 
 (deftest scope-tests
   (testing "system is created once when system-scope is :test"
-    (let [test-test-plan (testable/load test-suite-test)]
-      (reset! starts 0)
-      (reset! stops 0)
-      (testable/run test-test-plan test-test-plan)
-      (is (= @starts 1))
-      (is (= @stops 1))))
+    (reset! starts 0)
+    (reset! stops 0)
+    (api/run test-config)
+    (is (= @starts 1))
+    (is (= @stops 1)))
 
   (testing "system is created per ns when system-scope is :ns"
-    (let [ns-test-plan (testable/load test-suite-ns)]
-      (reset! starts 0)
-      (reset! stops 0)
-      (testable/run ns-test-plan ns-test-plan)
-      (is (= @starts 3))
-      (is (= @stops 3)))))
+    (reset! starts 0)
+    (reset! stops 0)
+    (api/run ns-config)
+    (is (= @starts 3))
+    (is (= @stops 3))))

--- a/test/caioaao/kaocha_greenlight/type_test.clj
+++ b/test/caioaao/kaocha_greenlight/type_test.clj
@@ -1,8 +1,9 @@
 (ns caioaao.kaocha-greenlight.type-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is testing]]
             [com.stuartsierra.component :as component]
             [kaocha.testable :as testable]
-            [kaocha.result]
+            [kaocha.api :as api]
+            [kaocha.result :as result]
             [matcher-combinators.test]
             [matcher-combinators.parser :refer [mimic-matcher]]
             [caioaao.kaocha-greenlight.test-suite.blue-test]
@@ -11,32 +12,37 @@
 
 (mimic-matcher matchers/equals clojure.lang.Var)
 
-(defn new-system-1 [& _]
+(defn new-system-1
+  [& _]
   (component/system-map :greenlight.test-test/component 6))
 
-(defn new-system-2 [& _]
+(defn new-system-2
+  [& _]
   (component/system-map :greenlight.test-test/component 5))
 
-(def test-suite-blue {::testable/type                       :caioaao.kaocha-greenlight/test
-                      ::testable/id                         :integration-blue
-                      :caioaao.kaocha-greenlight/new-system 'caioaao.kaocha-greenlight.type-test/new-system-1
-                      :kaocha/ns-patterns                   ["test-suite.blue-test$"]
-                      :kaocha/source-paths                  ["src"]
-                      :kaocha/test-paths                    ["test"]})
+(def test-suite-blue
+  {::testable/type                       :caioaao.kaocha-greenlight/test
+   ::testable/id                         :integration-blue
+   :caioaao.kaocha-greenlight/new-system 'caioaao.kaocha-greenlight.type-test/new-system-1
+   :kaocha/ns-patterns                   ["test-suite.blue-test$"]
+   :kaocha/source-paths                  ["src"]
+   :kaocha/test-paths                    ["test"]})
 
-(def test-suite-red {::testable/type                       :caioaao.kaocha-greenlight/test
-                     ::testable/id                         :integration-red
-                     :caioaao.kaocha-greenlight/new-system 'caioaao.kaocha-greenlight.type-test/new-system-2
-                     :kaocha/ns-patterns                   ["test-suite.red-test$"]
-                     :kaocha/source-paths                  ["src"]
-                     :kaocha/test-paths                    ["test"]})
+(def test-suite-red
+  {::testable/type                       :caioaao.kaocha-greenlight/test
+   ::testable/id                         :integration-red
+   :caioaao.kaocha-greenlight/new-system 'caioaao.kaocha-greenlight.type-test/new-system-2
+   :kaocha/ns-patterns                   ["test-suite.red-test$"]
+   :kaocha/source-paths                  ["src"]
+   :kaocha/test-paths                    ["test"]})
 
-(def full-test-suite {::testable/type                       :caioaao.kaocha-greenlight/test
-                      ::testable/id                         :integration-full
-                      :caioaao.kaocha-greenlight/new-system 'caioaao.kaocha-greenlight.type-test/new-system-1
-                      :kaocha/ns-patterns                   ["test-suite.*-test$"]
-                      :kaocha/source-paths                  ["src"]
-                      :kaocha/test-paths                    ["test"]})
+(def full-test-suite
+  {::testable/type                       :caioaao.kaocha-greenlight/test
+   ::testable/id                         :integration-full
+   :caioaao.kaocha-greenlight/new-system 'caioaao.kaocha-greenlight.type-test/new-system-1
+   :kaocha/ns-patterns                   ["test-suite.*-test$"]
+   :kaocha/source-paths                  ["src"]
+   :kaocha/test-paths                    ["test"]})
 
 (deftest loading-tests
   (testing "contains test suite info"
@@ -67,31 +73,31 @@
     (is (= "integration-red (greenlight)"
            (:kaocha.testable/desc (testable/load test-suite-red))))))
 
-(let [blue-test-plan    (testable/load test-suite-blue)
-      red-test-plan     (testable/load test-suite-red)
-      full-test-plan    (testable/load full-test-suite)
-      blue-results      (testable/run blue-test-plan blue-test-plan)
-      red-results       (testable/run red-test-plan red-test-plan)
-      full-test-results (testable/run full-test-plan full-test-plan)]
-  (deftest running-tests
-    (testing "counts are correctly tracked"
-      (is (match? #:kaocha.result{:count   1
-                                  :error   0
-                                  :fail    0
-                                  :pass    13
-                                  :pending 0}
-                  (kaocha.result/testable-totals blue-results)))
+(deftest running-tests
+  (testing "counts are correctly tracked"
+    (is (match? #:kaocha.result{:count   1
+                                :error   0
+                                :fail    0
+                                :pass    13
+                                :pending 0}
+                (-> {:kaocha/tests [test-suite-blue]}
+                    api/run
+                    result/testable-totals)))
 
-      (is (match? #:kaocha.result{:count   1
-                                  :error   0
-                                  :fail    1
-                                  :pass    9
-                                  :pending 0}
-                  (kaocha.result/testable-totals red-results)))
+    (is (match? #:kaocha.result{:count   1
+                                :error   0
+                                :fail    1
+                                :pass    9
+                                :pending 0}
+                (-> {:kaocha/tests [test-suite-red]}
+                    api/run
+                    result/testable-totals)))
 
-      (is (match? #:kaocha.result{:count   2
-                                  :error   0
-                                  :fail    0
-                                  :pass    26
-                                  :pending 0}
-                  (kaocha.result/testable-totals full-test-results))))))
+    (is (match? #:kaocha.result{:count   2
+                                :error   0
+                                :fail    0
+                                :pass    26
+                                :pending 0}
+                (-> {:kaocha/tests [full-test-suite]}
+                    api/run
+                    result/testable-totals)))))


### PR DESCRIPTION
Well, I went to use my new feature in my own project and…it was broken. Oops. This fixes that breakage by actually adding the config keys to the test-plan, and then tests it through the front door, via `kaocha.api/run`. 

I also bumped greenlight and added some tests to verify some new functionality.