### PR TITLE
Add :var system scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ you're using ephemeral datastores:
           :caioaao.kaocha-greenlight/system-scope :ns}]}
 ```
 
+You may also configure `kaocha-greenlight` to create a new system for each test
+var, for the same reasons as above:
+
+```clojure
+#kaocha/v1
+{:tests [{:id           :integration
+          :type         :caioaao.kaocha-greenlight/test
+          :test-paths   ["test"]
+          :source-paths ["src"]
+          :ns-patterns  ["-flow$"]
+          :caioaao.kaocha-greenlight/new-system my.app/system-map
+          :caioaao.kaocha-greenlight/system-scope :var}]}
+```
+
 For documentation on how to run tests, refer to [Kaocha](/lambdaisland/kaocha). For documentation regarding writing tests, refer to [Greenlight](/amperity/greenlight).
 
 ## License

--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
                  [lambdaisland/kaocha "1.0.672"]]
   :aliases {"test" ["run" "-m" "kaocha.runner"]}
   :profiles {:dev {:dependencies [[nubank/matcher-combinators "0.4.2"]
+                                  [orchestra "2020.07.12-1"]
                                   [org.clojure/test.check "1.1.0"]
                                   [expound "0.8.5"]]
                    :source-paths ["dev"]

--- a/src/caioaao/kaocha_greenlight/test.clj
+++ b/src/caioaao/kaocha_greenlight/test.clj
@@ -34,7 +34,7 @@
 
 (s/def :caioaao.kaocha-greenlight/new-system symbol?)
 
-(s/def :caioaao.kaocha-greenlight/system-scope #{:test :ns})
+(s/def :caioaao.kaocha-greenlight/system-scope #{:test :ns :var})
 
 (s/def :caioaao.kaocha-greenlight/test
   (s/keys :req [::testable/type

--- a/src/caioaao/kaocha_greenlight/test/var.clj
+++ b/src/caioaao/kaocha_greenlight/test/var.clj
@@ -16,7 +16,7 @@
    :kaocha.result/count   1})
 
 (defn report
-  [options event]
+  [event]
   (when (= :step-end (:type event))
     (->> (:step event)
          ::step/reports
@@ -32,7 +32,7 @@
                    {:caioaao.kaocha-greenlight.test/keys [system]}]
                 (ctest/do-report {:type :begin-test-var, :var test-var})
                 (binding [ctest/*report-counters* (ref ctest/*initial-report-counters*)
-                          test/*report*           (partial report {:print-color true})]
+                          test/*report*           report]
                   (test/run-test! system (test-var))
                   (ctest/do-report {:type :end-test-var, :var test-var})
                   (merge testable (test-results->kaocha @ctest/*report-counters*))))))

--- a/src/caioaao/kaocha_greenlight/test/var.clj
+++ b/src/caioaao/kaocha_greenlight/test/var.clj
@@ -1,19 +1,22 @@
 (ns caioaao.kaocha-greenlight.test.var
-  (:require [kaocha.testable :as testable]
-            [clojure.test :as ctest]
+  (:require [caioaao.kaocha-greenlight.runner :as runner]
             [clojure.spec.alpha :as s]
-            [kaocha.hierarchy :as hierarchy]
+            [clojure.test :as ctest]
+            [greenlight.step :as step]
             [greenlight.test :as test]
-            [greenlight.step :as step]))
+            [kaocha.hierarchy :as hierarchy]
+            [kaocha.testable :as testable]))
 
-(defn test-results->kaocha [rs]
+(defn test-results->kaocha
+  [rs]
   {:kaocha.result/pass    (:pass rs 0)
    :kaocha.result/error   (:error rs 0)
    :kaocha.result/fail    (:fail rs 0)
    :kaocha.result/pending (:pending rs 0)
    :kaocha.result/count   1})
 
-(defn report [options event]
+(defn report
+  [options event]
   (when (= :step-end (:type event))
     (->> (:step event)
          ::step/reports
@@ -21,14 +24,18 @@
   (ctest/do-report event))
 
 (defmethod testable/-run :caioaao.kaocha-greenlight.test/var
-  [{:caioaao.kaocha-greenlight.test/keys [test-var] :as testable}
-   {:caioaao.kaocha-greenlight.test/keys [system]}]
-  (ctest/do-report {:type :begin-test-var, :var test-var})
-  (binding [ctest/*report-counters* (ref ctest/*initial-report-counters*)
-            test/*report* (partial report {:print-color true})]
-    (test/run-test! system (test-var))
-    (ctest/do-report {:type :end-test-var, :var test-var})
-    (merge testable (test-results->kaocha @ctest/*report-counters*))))
+  [testable test-plan]
+  (runner/run testable
+              test-plan
+              :var
+              (fn [{:caioaao.kaocha-greenlight.test/keys [test-var] :as testable}
+                   {:caioaao.kaocha-greenlight.test/keys [system]}]
+                (ctest/do-report {:type :begin-test-var, :var test-var})
+                (binding [ctest/*report-counters* (ref ctest/*initial-report-counters*)
+                          test/*report*           (partial report {:print-color true})]
+                  (test/run-test! system (test-var))
+                  (ctest/do-report {:type :end-test-var, :var test-var})
+                  (merge testable (test-results->kaocha @ctest/*report-counters*))))))
 
 (s/def :caioaao.kaocha-greenlight.test/test-var var?)
 (s/def :caioaao.kaocha-greenlight.test/var (s/keys :req [::testable/type :caioaao.kaocha-greenlight.test/test-var]))

--- a/test/caioaao/kaocha_greenlight/scope_suite/one_test.clj
+++ b/test/caioaao/kaocha_greenlight/scope_suite/one_test.clj
@@ -1,10 +1,16 @@
 (ns caioaao.kaocha-greenlight.scope-suite.one-test
   (:require
-   [greenlight.step :as step]
+   [greenlight.step :as step :refer [defstep]]
    [greenlight.test :refer [deftest]]))
+
+(defstep noop-step
+  :title  "Noop Step"
+  :test   (constantly nil))
 
 (deftest one-test
   "A sample greenlight test in the one test suite"
-  #::step{:name   'noop-step
-          :title  "Noop Step"
-          :test   (constantly nil)})
+  (noop-step))
+
+(deftest another-one-test
+  "Another sample greenlight test in the one test suite"
+  (noop-step))

--- a/test/caioaao/kaocha_greenlight/scope_suite/three_test.clj
+++ b/test/caioaao/kaocha_greenlight/scope_suite/three_test.clj
@@ -1,11 +1,16 @@
 (ns caioaao.kaocha-greenlight.scope-suite.three-test
   (:require
-   [clojure.test :refer [is]]
    [greenlight.step :as step :refer [defstep]]
    [greenlight.test :as test :refer [deftest]]))
 
+(defstep noop-step
+  :title  "Noop Step"
+  :test   (constantly nil))
+
 (deftest three-test
   "A sample greenlight test in the three test suite"
-  #::step{:name   'noop-step
-          :title  "Noop Step"
-          :test   (constantly nil)})
+  (noop-step))
+
+(deftest another-three-test
+  "Another sample greenlight test in the three test suite"
+  (noop-step))

--- a/test/caioaao/kaocha_greenlight/scope_suite/two_test.clj
+++ b/test/caioaao/kaocha_greenlight/scope_suite/two_test.clj
@@ -1,11 +1,16 @@
 (ns caioaao.kaocha-greenlight.scope-suite.two-test
   (:require
-   [clojure.test :refer [is]]
    [greenlight.step :as step :refer [defstep]]
    [greenlight.test :as test :refer [deftest]]))
 
+(defstep noop-step
+  :title  "Noop Step"
+  :test   (constantly nil))
+
 (deftest two-test
   "A sample greenlight test in the two test suite"
-  #::step{:name   'noop-step
-          :title  "Noop Step"
-          :test   (constantly nil)})
+  (noop-step))
+
+(deftest another-two-test
+  "Another sample greenlight test in the two test suite"
+  (noop-step))

--- a/test/caioaao/kaocha_greenlight/scope_test.clj
+++ b/test/caioaao/kaocha_greenlight/scope_test.clj
@@ -40,6 +40,16 @@
                    :caioaao.kaocha-greenlight/new-system   'caioaao.kaocha-greenlight.scope-test/new-system
                    :caioaao.kaocha-greenlight/system-scope :ns}]})
 
+(def var-config
+  {:kaocha/tests [{:kaocha.testable/type :caioaao.kaocha-greenlight/test
+                   :kaocha.testable/id   :integration-test
+                   :kaocha/ns-patterns   ["scope-suite.*-test$"]
+                   :kaocha/source-paths  ["src"]
+                   :kaocha/test-paths    ["test"]
+
+                   :caioaao.kaocha-greenlight/new-system   'caioaao.kaocha-greenlight.scope-test/new-system
+                   :caioaao.kaocha-greenlight/system-scope :var}]})
+
 (deftest scope-tests
   (testing "system is created once when system-scope is :test"
     (reset! starts 0)
@@ -53,4 +63,11 @@
     (reset! stops 0)
     (api/run ns-config)
     (is (= @starts 3))
-    (is (= @stops 3))))
+    (is (= @stops 3)))
+
+  (testing "system is created per var when system-scope is :var"
+    (reset! starts 0)
+    (reset! stops 0)
+    (api/run var-config)
+    (is (= @starts 6))
+    (is (= @stops 6))))

--- a/tests.edn
+++ b/tests.edn
@@ -1,7 +1,9 @@
 #kaocha/v1
- {:kaocha/plugins [:kaocha.plugin/profiling
-                   :kaocha.plugin/orchestra
-                   :kaocha.plugin.alpha/spec-test-check]
+ {:plugins [:kaocha.plugin/profiling
+            :kaocha.plugin/orchestra
+            :kaocha.plugin.alpha/spec-test-check]
+
+  :reporter kaocha.report/documentation
 
   :clojure.spec.test.check/instrument?    true
   :clojure.spec.test.check/check-asserts? true}

--- a/tests.edn
+++ b/tests.edn
@@ -1,5 +1,6 @@
 #kaocha/v1
  {:kaocha/plugins [:kaocha.plugin/profiling
+                   :kaocha.plugin/orchestra
                    :kaocha.plugin.alpha/spec-test-check]
 
   :clojure.spec.test.check/instrument?    true


### PR DESCRIPTION
It was really easy to wrap the test-var runner with `caioaao.kaocha-greenlight.runner/run` to enable starting and stopping a new system per test var!

I've expanded the scope suite to ensure that start and stop are called at the correct points.