### PR TITLE
Fix bug where testable ID was a stringified var

### DIFF
--- a/src/caioaao/kaocha_greenlight/test/ns.clj
+++ b/src/caioaao/kaocha_greenlight/test/ns.clj
@@ -9,7 +9,7 @@
 (defn- test-var->testable
   [v]
   {::testable/type                          :caioaao.kaocha-greenlight.test/var
-   ::testable/id                            (keyword (str v))
+   ::testable/id                            (keyword (symbol v))
    :caioaao.kaocha-greenlight.test/test-var v})
 
 (defn- test-vars

--- a/test/caioaao/kaocha_greenlight/type_test.clj
+++ b/test/caioaao/kaocha_greenlight/type_test.clj
@@ -55,7 +55,7 @@
                                            :kaocha.testable/desc   "caioaao.kaocha-greenlight.test-suite.blue-test"
                                            :kaocha.ns/name         'caioaao.kaocha-greenlight.test-suite.blue-test
                                            :kaocha.test-plan/tests [{:kaocha.testable/type                    :caioaao.kaocha-greenlight.test/var
-                                                                     :kaocha.testable/id                      :#'caioaao.kaocha-greenlight.test-suite.blue-test/sample-test
+                                                                     :kaocha.testable/id                      :caioaao.kaocha-greenlight.test-suite.blue-test/sample-test
                                                                      :caioaao.kaocha-greenlight.test/test-var #'caioaao.kaocha-greenlight.test-suite.blue-test/sample-test}]}]}
                 (testable/load test-suite-blue)))
     (is (match? {:kaocha.test-plan/tests [{:kaocha.testable/type   :caioaao.kaocha-greenlight.test/ns
@@ -63,7 +63,7 @@
                                            :kaocha.testable/desc   "caioaao.kaocha-greenlight.test-suite.red-test"
                                            :kaocha.ns/name         'caioaao.kaocha-greenlight.test-suite.red-test
                                            :kaocha.test-plan/tests [{:kaocha.testable/type                    :caioaao.kaocha-greenlight.test/var
-                                                                     :kaocha.testable/id                      :#'caioaao.kaocha-greenlight.test-suite.red-test/sample-test
+                                                                     :kaocha.testable/id                      :caioaao.kaocha-greenlight.test-suite.red-test/sample-test
                                                                      :caioaao.kaocha-greenlight.test/test-var #'caioaao.kaocha-greenlight.test-suite.red-test/sample-test}]}]}
                 (testable/load test-suite-red))))
 


### PR DESCRIPTION
This fixes an issue where a test ID was being created as

`:#'some-ns/some-test`

rather than

`:some-ns/some-test`

Fixes running a single test from the REPL.