### PR TITLE
Use Greenlight's ManagedSystem protocol

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             - "~/.m2"
       - run:
           command: |
-            lein test
+            bin/kaocha
 
   lint:
     docker:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+.clj-kondo
+.lsp

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![CircleCI](https://circleci.com/gh/caioaao/kaocha-greenlight/tree/master.svg?style=svg)](https://circleci.com/gh/caioaao/kaocha-greenlight/tree/master) [![Clojars Project](https://img.shields.io/clojars/v/caioaao/kaocha-greenlight.svg)](https://clojars.org/caioaao/kaocha-greenlight)
+[![CircleCI](https://circleci.com/gh/caioaao/kaocha-greenlight/tree/master.svg?style=svg)](https://circleci.com/gh/caioaao/kaocha-greenlight/tree/master)
+[![Clojars
+Project](https://img.shields.io/clojars/v/caioaao/kaocha-greenlight.svg)](https://clojars.org/caioaao/kaocha-greenlight)
 
 # kaocha-greenlight
 
@@ -6,11 +8,21 @@ Kaocha plugin to run [greenlight](/amperity/greenlight) tests.
 
 ## Installing
 
-The project is published through Clojars with the identifier `caioaao/kaocha-greenlight`. You can find version information for the latest release at https://clojars.org/caioaao/kaocha-greenlight.
+The project is published through Clojars with the identifier
+[`caioaao/kaocha-greenlight`](https://clojars.org/caioaao/kaocha-greenlight).
+You can find version information for the latest release on
+[GitHub](https://clojars.org/caioaao/kaocha-greenlight).
 
 ## Usage
 
-Declare a test suite on your [Kaocha config file](https://cljdoc.org/d/lambdaisland/kaocha/0.0-413/doc/3-configuration) with the type `:caioaao.kaocha-greenlight/test`. You'll also need to provide a value for `:caioaao.kaocha-greenlight/new-system`, which should be a function that receives no arguments and returns [a stuartsierra's system map](https://github.com/stuartsierra/component).
+Declare a test suite on your [Kaocha config
+file](https://cljdoc.org/d/lambdaisland/kaocha/1.66.1034/doc/3-configuration) with
+the type `:caioaao.kaocha-greenlight/test`. You'll also need to provide a value
+for `:caioaao.kaocha-greenlight/new-system`, which should be a function that
+receives no arguments and returns [a greenlight
+ManagedSystem](https://github.com/amperity/greenlight#test-system), [a
+stuartsierra's system map](https://github.com/stuartsierra/component), or (in
+rare cases) any other object that will not have its lifecycle managed.
 
 A `tests.edn` example:
 
@@ -53,7 +65,9 @@ var, for the same reasons as above:
           :caioaao.kaocha-greenlight/system-scope :var}]}
 ```
 
-For documentation on how to run tests, refer to [Kaocha](/lambdaisland/kaocha). For documentation regarding writing tests, refer to [Greenlight](/amperity/greenlight).
+For documentation on how to run tests, refer to
+[Kaocha](https://github.com/lambdaisland/kaocha). For documentation regarding
+writing tests, refer to [Greenlight](https://github.com/amperity/greenlight).
 
 ## License
 

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+lein kaocha "$@"

--- a/project.clj
+++ b/project.clj
@@ -6,9 +6,10 @@
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [amperity/greenlight "0.6.1"]
                  [lambdaisland/kaocha "1.66.1034"]]
-  :aliases {"test" ["run" "-m" "kaocha.runner"]}
+  :aliases {"kaocha" ["run" "-m" "kaocha.runner"]}
   :profiles {:dev {:dependencies [[nubank/matcher-combinators "3.5.0"]
                                   [orchestra "2021.01.01-1"]
+                                  [com.stuartsierra/component "1.1.0"]
                                   [org.clojure/test.check "1.1.0"]
                                   [expound "0.9.0"]]
                    :source-paths ["dev"]

--- a/src/caioaao/kaocha_greenlight/runner.clj
+++ b/src/caioaao/kaocha_greenlight/runner.clj
@@ -1,6 +1,6 @@
 (ns caioaao.kaocha-greenlight.runner
   (:require
-   [com.stuartsierra.component :as component]))
+   [greenlight.runner :as runner]))
 
 (defn run
   [testable test-plan level run-fn]
@@ -15,11 +15,11 @@
       (run-fn testable test-plan)
       (let [system    (-> test-plan
                           :caioaao.kaocha-greenlight.test/system
-                          component/start)
+                          runner/start-system)
             test-plan (assoc test-plan
                              :caioaao.kaocha-greenlight.test/system
                              system)]
         (try
           (run-fn testable test-plan)
           (finally
-            (component/stop system)))))))
+            (runner/stop-system system)))))))

--- a/test/caioaao/kaocha_greenlight/error_test.clj
+++ b/test/caioaao/kaocha_greenlight/error_test.clj
@@ -1,7 +1,6 @@
 (ns caioaao.kaocha-greenlight.error-test
   (:require
    [clojure.test :refer [deftest testing is]]
-   [com.stuartsierra.component :as component]
    [kaocha.api :as api]
    [kaocha.result :as result]
    [matcher-combinators.matchers :as matchers]
@@ -12,7 +11,7 @@
 
 (defn new-system
   [& _]
-  (component/system-map :greenlight.test-test/component {}))
+  {:greenlight.test-test/component {}})
 
 (def error-config
   {:kaocha/tests [{:kaocha.testable/type :caioaao.kaocha-greenlight/test

--- a/test/caioaao/kaocha_greenlight/scope_test.clj
+++ b/test/caioaao/kaocha_greenlight/scope_test.clj
@@ -1,7 +1,7 @@
 (ns caioaao.kaocha-greenlight.scope-test
   (:require
    [clojure.test :refer [deftest testing is]]
-   [com.stuartsierra.component :as component]
+   [greenlight.runner :as runner]
    [kaocha.api :as api]
    [matcher-combinators.matchers :as matchers]
    [matcher-combinators.parser :refer [mimic-matcher]]))
@@ -13,14 +13,12 @@
 
 (defn new-system
   [& _]
-  (component/system-map :greenlight.test-test/component
-                        (with-meta {}
-                          {`component/start (fn [this]
-                                              (swap! starts inc)
-                                              this)
-                           `component/stop  (fn [this]
-                                              (swap! stops inc)
-                                              this)})))
+  (with-meta {} {`runner/start-system (fn [this]
+                                        (swap! starts inc)
+                                        this)
+                 `runner/stop-system  (fn [this]
+                                        (swap! stops inc)
+                                        this)}))
 
 (def test-config
   {:kaocha/tests [{:kaocha.testable/type :caioaao.kaocha-greenlight/test

--- a/test/caioaao/kaocha_greenlight/type_test.clj
+++ b/test/caioaao/kaocha_greenlight/type_test.clj
@@ -4,6 +4,7 @@
    [caioaao.kaocha-greenlight.test-suite.red-test]
    [clojure.test :refer [deftest is testing]]
    [com.stuartsierra.component :as component]
+   [greenlight.runner :as runner]
    [kaocha.api :as api]
    [kaocha.result :as result]
    [kaocha.testable :as testable]


### PR DESCRIPTION
Using this protocol removes an implicit dependency on component present
in the library. ManagedSystem is implemented for component's SystemMaps,
as well as arbitrary Objects.

Updated README (and cleaned it up a bit).