### PR TITLE
Bugfix: ensure that :caioaao.kaocha-greenlight.test/var is a leaf

### DIFF
--- a/src/caioaao/kaocha_greenlight/test/ns.clj
+++ b/src/caioaao/kaocha_greenlight/test/ns.clj
@@ -1,6 +1,7 @@
 (ns caioaao.kaocha-greenlight.test.ns
   (:require
    [caioaao.kaocha-greenlight.runner :as runner]
+   [caioaao.kaocha-greenlight.test.var]
    [clojure.spec.alpha :as s]
    [clojure.test :as t]
    [kaocha.hierarchy :as hierarchy]


### PR DESCRIPTION
By eagerly requiring this namespace, we ensure that
kaocha.hierarchy/derive! is called and that individual tests are
considered leaves.