### PR TITLE
Correctly report test timeouts as errors

### DIFF
--- a/test/caioaao/kaocha_greenlight/timeout_suite/timeout_test.clj
+++ b/test/caioaao/kaocha_greenlight/timeout_suite/timeout_test.clj
@@ -1,0 +1,12 @@
+(ns caioaao.kaocha-greenlight.timeout-suite.timeout-test
+  (:require
+   [clojure.test :refer [is]]
+   [greenlight.step :as step]
+   [greenlight.test :refer [deftest]]))
+
+(deftest timeout-test
+  "A sample greenlight test in the timeout test suite"
+  #::step{:name    'timeout-step
+          :title   "Timeout Step"
+          :timeout 0
+          :test    (fn [& _] (Thread/sleep 1000))})

--- a/test/caioaao/kaocha_greenlight/timeout_test.clj
+++ b/test/caioaao/kaocha_greenlight/timeout_test.clj
@@ -1,0 +1,33 @@
+(ns caioaao.kaocha-greenlight.timeout-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [kaocha.api :as api]
+   [kaocha.result :as result]
+   [matcher-combinators.matchers :as matchers]
+   [matcher-combinators.parser :refer [mimic-matcher]]))
+
+(mimic-matcher matchers/equals clojure.lang.Var)
+
+(defn new-system
+  [& _]
+  {:greenlight.test-test/component {}})
+
+(def timeout-config
+  {:kaocha/tests [{:kaocha.testable/type :caioaao.kaocha-greenlight/test
+                   :kaocha.testable/id   :integration-test
+                   :kaocha/ns-patterns   ["timeout-suite.*-test$"]
+                   :kaocha/source-paths  ["src"]
+                   :kaocha/test-paths    ["test"]
+
+                   :caioaao.kaocha-greenlight/new-system 'caioaao.kaocha-greenlight.timeout-test/new-system}]})
+
+(deftest timeout-test
+  (testing "correctly handles timeouts"
+    (is (match? #:kaocha.result{:count   1
+                                :error   1
+                                :fail    0
+                                :pass    0
+                                :pending 0}
+                (-> timeout-config
+                    api/run
+                    result/testable-totals)))))


### PR DESCRIPTION
Inspects the result of `run-test!` to check if the result was a timeout, and reports it with the correct message if so.